### PR TITLE
Normalize newlines in text fixtures to \n

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob": "^7.0.0",
     "minifyify": "^7.3.0",
     "mocha": "^2.2.5",
+    "normalize-newline": "^2.0.0",
     "source-map": "^0.5.3",
     "string.prototype.repeat": "^0.2.0",
     "uglify-js": "^2.6.0",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var fs = require( 'fs' )
 var path = require( 'path' )
 var acorn = require( 'acorn' )
 var astravel = require( 'astravel' )
+var normalizeNewline = require( 'normalize-newline' )
 var astring
 try {
 	astring = require( '../dist/astring.debug' )
@@ -42,7 +43,7 @@ describe( 'Syntax check', function() {
 		sourceType: 'module'
 	}
 	files.forEach( function( filename ) {
-		var code = fs.readFileSync( path.join( dirname, filename ), 'utf8' )
+		var code = normalizeNewline( fs.readFileSync( path.join( dirname, filename ), 'utf8' ) )
 		it( filename.substring( 0, filename.length - 3 ), function() {
 			var ast = acorn.parse( code, options )
 			assert.equal( astring( ast ), code )
@@ -60,7 +61,7 @@ describe( 'Tree comparison', function() {
 		sourceType: 'module'
 	}
 	files.forEach( function( filename ) {
-		var code = fs.readFileSync( path.join( dirname, filename ), 'utf8' )
+		var code = normalizeNewline( fs.readFileSync( path.join( dirname, filename ), 'utf8' ) )
 		it( filename.substring( 0, filename.length - 3 ), function() {
 			var ast = acorn.parse( code, options )
 			var formattedAst = acorn.parse( astring( ast ), options )
@@ -77,7 +78,7 @@ describe( 'Deprecated syntax check', function() {
 	var dirname = path.join( __dirname, 'deprecated' )
 	var files = fs.readdirSync( dirname ).sort()
 	files.forEach( function( filename ) {
-		var code = fs.readFileSync( path.join( dirname, filename ), 'utf8' )
+		var code = normalizeNewline( fs.readFileSync( path.join( dirname, filename ), 'utf8' ) )
 		var version = parseInt( filename.substring( 2, filename.length - 3 ) )
 		it( 'es' + version, function() {
 			var ast = acorn.parse( code, { ecmaVersion: version } )
@@ -95,7 +96,7 @@ describe( 'Comment generation', function() {
 		comments: true
 	}
 	files.forEach( function( filename ) {
-		var code = fs.readFileSync( path.join( dirname, filename ), 'utf8' )
+		var code = normalizeNewline( fs.readFileSync( path.join( dirname, filename ), 'utf8' ) )
 		it( filename.substring( 0, filename.length - 3 ), function() {
 			var comments = []
 			var ast = acorn.parse( code, { ecmaVersion: 6, locations: true, onComment: comments } )

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -4,6 +4,7 @@ var path = require( 'path' )
 var glob = require( 'glob' )
 var acorn = require( 'acorn' )
 var astravel = require( 'astravel' )
+var normalizeNewline = require( 'normalize-newline' )
 var astring
 try {
 	astring = require( '../dist/astring.debug' )
@@ -47,7 +48,7 @@ console.log( 'Found', files.length, 'files, processing them…' )
 var processedFiles = 0, errorFiles = 0
 
 files.forEach( function( filename ) {
-	var code = fs.readFileSync( filename, 'utf8' )
+	var code = normalizeNewline( fs.readFileSync( filename, 'utf8' ) )
 	try {
 		var ast = acorn.parse( code, options )
 		stripLocation.go( ast )


### PR DESCRIPTION
This eases development on Windows, where Git defaults to CRLF (`\r\n`) in checked out text files.

(This came up while developing #8 - the tests were failing to begin with, because `"\n" != "\r\n"` was tripping up all the full-file comparisons.)