### PR TITLE
Add `ClassBody` as alias of `BlockStatement`

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -190,7 +190,7 @@ function hasCallExpression( node ) {
 }
 
 
-let ForInStatement, FunctionDeclaration, RestElement, BinaryExpression, ArrayExpression
+let ForInStatement, FunctionDeclaration, RestElement, BinaryExpression, ArrayExpression, BlockStatement
 
 
 export const defaultGenerator = {
@@ -212,7 +212,7 @@ export const defaultGenerator = {
 		if ( writeComments && node.trailingComments != null )
 			formatComments( node.trailingComments, output, indent, lineEnd )
 	},
-	BlockStatement( node, state ) {
+	BlockStatement: BlockStatement = function( node, state ) {
 		const indent = state.indent.repeat( state.indentLevel++ )
 		const { lineEnd, output, writeComments } = state
 		const statementIndent = indent + state.indent
@@ -245,6 +245,7 @@ export const defaultGenerator = {
 		output.write( '}' )
 		state.indentLevel--
 	},
+	ClassBody: BlockStatement,
 	EmptyStatement( node, state ) {
 		state.output.write( ';' )
 	},
@@ -461,7 +462,7 @@ export const defaultGenerator = {
 			this[ node.superClass.type ]( node.superClass, state )
 			output.write( ' ' )
 		}
-		this.BlockStatement( node.body, state )
+		this[ node.body.type ]( node.body, state )
 	},
 	ImportDeclaration( node, state ) {
 		const { output } = state


### PR DESCRIPTION
It's a small change, but a) it's more correct, and b) now I can reimplement `ClassBody` in an extension without having to reimplement `ClassDeclaration`/`ClassExpression`

The actual aliasing follows the example of `FunctionDeclaration`/`FunctionExpression`.