### PR TITLE
Switch to un-minified build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 /node_modules
-/dist/astring.js
 /dist/astring.debug.js
 /test
 /src

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "astring",
   "version": "0.6.1",
   "description": "JavaScript code generator from an ESTree-compliant AST.",
-  "main": "./dist/astring.min.js",
+  "main": "./dist/astring.js",
   "bin": {
     "astring": "./bin/astring"
   },
   "scripts": {
     "test": "mocha test/index.js",
     "full-test": "node test/scripts.js",
-    "prepublish": "browserify --transform [ babelify ] --plugin [ minifyify --no-map ] --no-builtins --standalone astring --entry ./src/export.js --outfile dist/astring.min.js",
+    "prepublish": "npm run build",
     "build": "browserify --transform [ babelify ] --no-builtins --standalone astring --entry ./src/export.js --outfile dist/astring.js",
     "start": "watchify --transform [ babelify ] --no-builtins --debug --verbose --standalone astring --entry ./src/export.js --outfile dist/astring.debug.js",
     "benchmark": "node ./test/benchmark.js"
@@ -37,7 +37,6 @@
     "eslint": "^2.2.0",
     "esotope": "^1.4.5",
     "glob": "^7.0.0",
-    "minifyify": "^7.3.0",
     "mocha": "^2.2.5",
     "source-map": "^0.5.3",
     "string.prototype.repeat": "^0.2.0",


### PR DESCRIPTION
The minified build has been something of a hurdle when trying to debug [astring-flow](https://github.com/motiz88/astring-flow), as I could not make any sense of stack traces inside Astring, nor make quick edits to pinpoint problems.

And I submit that there's no real need to publish a minified build to npm, as anyone who actually needs minification is likely doing it anyway in a build step (or should be doing so).