### PR TITLE
Build system changes - remove Browserify, astring.debug.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015-loose"]
+  "presets": ["./babel-preset-es2015-loose-umd"],
+  "env": {
+    "development": {
+      "sourceMaps": true
+    }
+  }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 /node_modules
-/dist/astring.js
 /dist/astring.debug.js
 /test
 /src

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 /dist/astring.debug.js
 /test
 /src
+.babelrc
+babel-preset*.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+   - "6"
    - "4.2"
    - "4.1"
    - "0.12"

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ cd astring
 npm install
 ```
 
-The path to the module file is `dist/astring.min.js` and can be linked to from an HTML webpage. When used in a browser environment, the module exposes a global variable `astring`:
+The path to the module file is `dist/astring.min.js` and it can be included from an HTML webpage. When used in a browser environment, the module exposes a global variable `astring`:
 
 ```html
-<script src="astring.min.js" type="text/javascript"></script>
+<script src="astring.js" type="text/javascript"></script>
 ```
 
+The module can also be used in the browser via a CommonJS bundler such as [Browserify](http://browserify.org) or [Webpack](https://webpack.github.io).
 
 
 ## Usage
@@ -155,7 +156,7 @@ var ast = {
 					type: "Identifier",
 					name: "callable"
 				},
-				arguments: []	
+				arguments: []
 			}
 		}
 	}],
@@ -207,24 +208,17 @@ All building scripts are defined in the `package.json` file and rely on the [Nod
 
 ### Production
 
-The source code of Astring is written in JavaScript 6 and located at `src/astring.js`. It is compiled down to a minified JavaScript 5 file located at `dist/astring.min.js` using [Browserify](http://browserify.org), [Babel](http://babeljs.io/) and [UglifyJS](https://github.com/mishoo/UglifyJS2). This is achieved by running:
+The source code of Astring is written in ECMAScript 2015 and located at `src/astring.js`. It is compiled down to a plain JavaScript (ES5) file located at `dist/astring.js` using [Babel](http://babeljs.io/). This is achieved by running:
 
 ```bash
 npm install
 ```
 
-If you are already using a JavaScript 6 to 5 compiler for your project, or a JavaScript 6 compliant interpreter, you can include the `src/astring.js` file directly.
-
-A non-minified and source map free version can be obtained at `dist/astring.js` by running:
-
-```bash
-npm run build
-```
-
+If you are already using an ES2015 to ES5 transpiler for your project, or running in an ES2015 compliant environment, you can include the `src/astring.js` file directly.
 
 ### Development
 
-If you are working on Astring, you can use [Watchify](https://github.com/substack/watchify) to build automatically at each modification a non-minified version (along with a source map for easy debugging) located at `dist/astring.debug.js` by running:
+If you are working on Astring, you can run the build in watch mode and including a source map, running:
 
 ```bash
 npm start

--- a/babel-preset-es2015-loose-umd.js
+++ b/babel-preset-es2015-loose-umd.js
@@ -1,0 +1,6 @@
+var modify = require( 'modify-babel-preset' )
+
+module.exports = modify( 'es2015-loose', {
+    'transform-es2015-modules-commonjs': false,
+    'transform-es2015-modules-umd': true
+} )

--- a/babel-preset-es2015-loose-umd.js
+++ b/babel-preset-es2015-loose-umd.js
@@ -1,6 +1,14 @@
 var modify = require( 'modify-babel-preset' )
 
-module.exports = modify( 'es2015-loose', {
+var LOOSE = { loose: true }
+
+module.exports = modify( 'es2015', {
+    'transform-es2015-template-literals': LOOSE,
+    'transform-es2015-classes': LOOSE,
+    'transform-es2015-computed-properties': LOOSE,
+    'transform-es2015-for-of': LOOSE,
+    'transform-es2015-spread': LOOSE,
+    'transform-es2015-destructuring': LOOSE,
     'transform-es2015-modules-commonjs': false,
-    'transform-es2015-modules-umd': true
+    'transform-es2015-modules-umd': LOOSE
 } )

--- a/bin/astring
+++ b/bin/astring
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
 
-var astring
-try {
-	astring = require( '../dist/astring' )
-} catch ( error ) {
-	astring = require( '../dist/astring.min' )
-}
+var astring =  require( '../dist/astring' )
 var version = require( '../package' ).version
 var fs = require( 'fs' )
 var path = require( 'path' )

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "astring",
   "version": "0.6.1",
   "description": "JavaScript code generator from an ESTree-compliant AST.",
-  "main": "./dist/astring.min.js",
+  "main": "./dist/astring.js",
   "bin": {
     "astring": "./bin/astring"
   },
   "scripts": {
     "test": "mocha test/index.js",
     "full-test": "node test/scripts.js",
-    "prepublish": "browserify --transform [ babelify ] --plugin [ minifyify --no-map ] --no-builtins --standalone astring --entry ./src/export.js --outfile dist/astring.min.js",
+    "prepublish": "npm run build",
     "build": "browserify --transform [ babelify ] --no-builtins --standalone astring --entry ./src/export.js --outfile dist/astring.js",
     "start": "watchify --transform [ babelify ] --no-builtins --debug --verbose --standalone astring --entry ./src/export.js --outfile dist/astring.debug.js",
     "benchmark": "node ./test/benchmark.js"
@@ -37,7 +37,6 @@
     "eslint": "^2.2.0",
     "esotope": "^1.4.5",
     "glob": "^7.0.0",
-    "minifyify": "^7.3.0",
     "mocha": "^2.2.5",
     "source-map": "^0.5.3",
     "string.prototype.repeat": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "astring",
   "version": "0.6.1",
   "description": "JavaScript code generator from an ESTree-compliant AST.",
-  "main": "./dist/astring.js",
+  "main": "./dist/astring",
   "bin": {
     "astring": "./bin/astring"
   },
@@ -10,8 +10,8 @@
     "test": "mocha test/index.js",
     "full-test": "node test/scripts.js",
     "prepublish": "npm run build",
-    "build": "browserify --transform [ babelify ] --no-builtins --standalone astring --entry ./src/export.js --outfile dist/astring.js",
-    "start": "watchify --transform [ babelify ] --no-builtins --debug --verbose --standalone astring --entry ./src/export.js --outfile dist/astring.debug.js",
+    "build": "cross-env BABEL_ENV=production babel src -d dist",
+    "start": "babel --watch src -d dist",
     "benchmark": "node ./test/benchmark.js"
   },
   "keywords": [
@@ -25,22 +25,25 @@
   },
   "author": "David Bonnet <david@bonnet.cc>",
   "license": "MIT",
+  "dependencies": {
+    "string.prototype.repeat": "^0.2.0"
+  },
   "devDependencies": {
     "acorn": "^3.0.4",
     "astravel": "^0.3.11",
+    "babel-cli": "^6.11.4",
+    "babel-core": "^6.13.1",
+    "babel-plugin-transform-es2015-modules-umd": "^6.12.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose": "^7.0.0",
-    "babelify": "^7.2.0",
     "benchmark": "^2.0.0",
-    "browserify": "^13.0.0",
+    "cross-env": "^2.0.0",
     "escodegen": "^1.6.1",
     "eslint": "^2.2.0",
     "esotope": "^1.4.5",
     "glob": "^7.0.0",
     "mocha": "^2.2.5",
     "source-map": "^0.5.3",
-    "string.prototype.repeat": "^0.2.0",
-    "uglify-js": "^2.6.0",
-    "watchify": "^3.6.0"
+    "uglify-js": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-core": "^6.13.1",
     "babel-plugin-transform-es2015-modules-umd": "^6.12.0",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2015-loose": "^7.0.0",
     "benchmark": "^2.0.0",
     "cross-env": "^2.0.0",
     "escodegen": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "esotope": "^1.4.5",
     "glob": "^7.0.0",
     "mocha": "^2.2.5",
+    "modify-babel-preset": "^2.1.1",
     "source-map": "^0.5.3",
     "uglify-js": "^2.6.0"
   }

--- a/src/astring.js
+++ b/src/astring.js
@@ -8,6 +8,8 @@
 // Please use the GitHub bug tracker to report issues:
 // https://github.com/davidbonnet/astring/issues
 
+require( 'string.prototype.repeat' )
+
 const { stringify } = JSON;
 
 
@@ -193,7 +195,7 @@ function hasCallExpression( node ) {
 let ForInStatement, FunctionDeclaration, RestElement, BinaryExpression, ArrayExpression
 
 
-export const defaultGenerator = {
+const defaultGenerator = {
 	Program( node, state ) {
 		const indent = state.indent.repeat( state.indentLevel )
 		const { lineEnd, output, writeComments } = state
@@ -890,7 +892,7 @@ class Stream {
 }
 
 
-export default function astring( node, options ) {
+module.exports = function astring( node, options ) {
 	/*
 	Returns a string representing the rendered code of the provided AST `node`.
 	The `options` are:
@@ -927,3 +929,5 @@ export default function astring( node, options ) {
 	const { output } = state
 	return output.data != null ? output.data : output
 }
+
+module.exports.defaultGenerator = defaultGenerator;

--- a/src/export.js
+++ b/src/export.js
@@ -1,4 +1,0 @@
-require( 'string.prototype.repeat' )
-var astring = require( './astring' )
-astring.default.defaultGenerator = astring.defaultGenerator
-module.exports = astring.default

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -4,19 +4,7 @@ var uglify = require( 'uglify-js' )
 var escodegen = require( 'escodegen' ).generate
 var esotope = require( 'esotope' ).generate
 var nodent = require( '../vendor/nodent' )
-var astring
-try {
-	astring = require( '../dist/astring.min' )
-	console.log( 'Using ./dist/astring.min.js' )
-} catch ( error ) {
-	try {
-		astring = require( '../dist/astring' )
-		console.log( 'Using ./dist/astring.js' )
-	} catch ( error ) {
-		astring = require( '../dist/astring.debug' )
-		console.log( 'Using ./dist/astring.debug.js' )
-	}
-}
+var astring = require( '../dist/astring' )
 var fs = require( 'fs' )
 var path = require( 'path' )
 

--- a/test/demo.html
+++ b/test/demo.html
@@ -73,7 +73,7 @@
     }
   </style>
   <script type="text/javascript" src="../node_modules/acorn/dist/acorn.js"></script>
-  <script type="text/javascript" src="../dist/astring.debug.js"></script>
+  <script type="text/javascript" src="../dist/astring.js"></script>
   <script type="text/javascript" src="../node_modules/astravel/dist/astravel.min.js"></script>
 </head>
 <body>

--- a/test/index.js
+++ b/test/index.js
@@ -3,19 +3,7 @@ var fs = require( 'fs' )
 var path = require( 'path' )
 var acorn = require( 'acorn' )
 var astravel = require( 'astravel' )
-var astring
-try {
-	astring = require( '../dist/astring.debug' )
-	console.log( 'Using ./dist/astring.debug.js' )
-} catch ( error ) {
-	try {
-		astring = require( '../dist/astring.min' )
-		console.log( 'Using ./dist/astring.min.js' )
-	} catch ( error ) {
-		astring = require( '../dist/astring' )
-		console.log( 'Using ./dist/astring.js' )
-	}
-}
+var astring = require( '../dist/astring' )
 
 
 var stripLocation = astravel.makeTraveler( {


### PR DESCRIPTION
Picking up from #12 on which this branch is based, here I propose to stop using Browserify. This is a one-file module with no dependencies so a bundler is actually overkill; and a UMD compile target suffices to keep browser compatibility. So `demo.html` still works :smile:

The use of a `String.prototype.repeat` polyfill complicates the issue, though - at least in theory. In this PR, I kept the polyfill (now as a runtime rather than build dependency) and it will work when using Astring on older Node.js versions, but I did not go to the trouble of bundling it for the browser.

Forcing a polyfill in a library (including the way it's already done now, in `export.js` and a build step) is technically a non-obvious side effect that may not be desired; I suggest that we either

1. use a private `repeat` implementation in Astring, not bound to `String.prototype`; or
2. document that `String.prototype.repeat` is required - it is [widely supported](https://kangax.github.io/compat-table/es6/#test-String.prototype_methods_String.prototype.repeat)  in current and recent JS engines, and users of older ones can install their own polyfill.

As a nice twist on (1), we can "polyfill" `repeat` on `state.indent` alone (when it's first assigned), not touch `String.prototype`, and still be able to do `state.indent.repeat()` freely. In this case I would make `state.indent` read-only to guard against reassignments that would take away the `repeat` member.

I will be happy to implement any of the above solutions so this PR doesn't break anything it's not trying to :smile: