### PR TITLE
Fixed code generating for (await f()).prop

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -82,6 +82,7 @@ const EXPRESSIONS_PRECEDENCE = {
   LogicalExpression: 13,
   ConditionalExpression: 4,
   AssignmentExpression: 3,
+  AwaitExpression: 2,
   YieldExpression: 2,
   RestElement: 1,
 }

--- a/test/syntax/async.js
+++ b/test/syntax/async.js
@@ -5,5 +5,7 @@ const a = {
 };
 const h = async () => {};
 async function j() {
+	(await g()).a;
+	await g().a;
 	return await f();
 }


### PR DESCRIPTION
Precedence for AwaitExpression is missing and astring in case of "(await
f()).prop" generates "await f().prop". It changes semantic of code.
Added precedence for AwaitExpression, the same as YeildExpression has.