### PR TITLE
Add support for standalone TemplateElement nodes

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -683,13 +683,16 @@ export const baseGenerator = {
     const { length } = expressions
     for (let i = 0; i < length; i++) {
       const expression = expressions[i]
-      state.write(quasis[i].value.raw)
+      this.TemplateElement(quasis[i], state)
       state.write('${')
       this[expression.type](expression, state)
       state.write('}')
     }
     state.write(quasis[quasis.length - 1].value.raw)
     state.write('`')
+  },
+  TemplateElement(node, state) {
+    state.write(node.value.raw)
   },
   TaggedTemplateExpression(node, state) {
     this[node.tag.type](node.tag, state)


### PR DESCRIPTION
Test Plan:

```javascript
const acorn = require('acorn');
const assert = require('assert');
const astring = require('astring');

const node = acorn.parse("`dsf${x}ppodskfa`").body[0].expression;
assert.strictEqual(node.type, 'TemplateLiteral');
for (const [i, expected] of [[0, 'dsf'], [1, 'ppodskfa']]) {
    const quasi = node.quasis[i];
    assert.strictEqual(quasi.type, 'TemplateElement');
    assert.strictEqual(astring.generate(quasi, {lineEnd: ''}), expected);
}
```