### PR TITLE
tolerate missing node.kind

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -773,7 +773,7 @@ export const baseGenerator = {
     state.indentLevel--
   },
   Property(node, state) {
-    if (node.method || node.kind[0] !== 'i') {
+    if (node.method || (node.kind && node.kind[0] !== 'i')) {
       // Either a method or of kind `set` or `get` (not `init`)
       this.MethodDefinition(node, state)
     } else {


### PR DESCRIPTION
problem is
```
astring.js:818
    if (node.method || node.kind[0] !== 'i') {
TypeError: Cannot read property '0' of undefined
```

this happens when i run
```
const lave = require('lave')
const astring = require('astring')
console.log('astr = '+astring.generate(lave({a: 1})))
```
lave = eval in reverse = get ast of a live object = https://github.com/jed/lave

with the proposed change, result is as expected
```
astr = ({
  "a": 1
});
```