### PR TITLE
fix invalid code generation, await arrow function

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -672,9 +672,15 @@ export const baseGenerator = {
     }
   },
   AwaitExpression(node, state) {
-    state.write('await ')
+    state.write('await ', node)
     if (node.argument) {
-      this[node.argument.type](node.argument, state)
+      if (node.argument.type === 'ArrowFunctionExpression') {
+        state.write('(', node)
+        this[node.argument.type](node.argument, state)
+        state.write(')', node)
+      } else {
+        this[node.argument.type](node.argument, state)
+      }
     }
   },
   TemplateLiteral(node, state) {

--- a/src/tests/fixtures/syntax/await.js
+++ b/src/tests/fixtures/syntax/await.js
@@ -1,0 +1,3 @@
+async function f() {
+  await (() => 1);
+}


### PR DESCRIPTION
Hi!

`astring` fails to generate the follow code.
```Javascript
async function f() {
  await (() => 1);
}
```

this PR check if an `AwaitExpression` have an `ArrowFunctionExpression` as argument and wraps it.