### PR TITLE
Add support for JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - Considerably faster than [Bublé](https://gitlab.com/Rich-Harris/buble) (up to 5×), [Escodegen](https://github.com/estools/escodegen) (up to 10×), [Babel](https://github.com/babel/babel) (up to 50×), [UglifyJS](https://github.com/mishoo/UglifyJS2) (up to 125×), and [Prettier](https://github.com/prettier/prettier) (up to 380×).
 - Supports source map generation with [Source Map](https://github.com/mozilla/source-map#sourcemapgenerator).
 - Supports comment generation with [Astravel](https://github.com/davidbonnet/astravel).
+- Optionally supports JSX.
 - No dependencies and small footprint (≈ 16 KB minified, ≈ 4 KB gziped).
 
 Checkout the [live demo](http://david.bonnet.cc/astring/demo/) showing Astring in action.
@@ -109,6 +110,11 @@ The `options` are:
 
 Base generator that can be used to [extend Astring](#extending).
 
+### `JSX: object`
+
+Handlers for JSX nodes. Can be combined with `GENERATOR` and/or your own
+generators to support JSX.
+
 ### `EXPRESSIONS_PRECEDENCE: object`
 
 Mapping of node types and their precedence level to let the generator know when to use parentheses.
@@ -187,6 +193,29 @@ var formattedCode = generate(ast, {
 })
 // Display generated source map
 console.log(map.toString())
+```
+
+### Supporting JSX
+
+```javascript
+import { Parser } from 'acorn'
+import acornJsx from 'acorn-jsx'
+import {generate, GENERATOR, JSX} from './dist/astring.js'
+
+// Parse with acorn:
+const acorn = Parser.extend(acornJsx())
+
+var ast = acorn.parse('console.log(<h1>Hello, world!</h1>)', {
+  ecmaVersion: 6,
+  sourceType: 'module',
+})
+
+// Serialize with astring:
+var code = generate(ast, {
+  generator: { ...GENERATOR, ...JSX },
+})
+
+console.log(code)
 ```
 
 ### Using writable streams

--- a/src/astring.js
+++ b/src/astring.js
@@ -233,6 +233,17 @@ function formatVariableDeclaration(state, node) {
   }
 }
 
+// Make sure that character references don’t pop up.
+// For example, the text `&copy;` should stay that way, and not turn into `©`.
+// We could encode all `&` (easy but verbose) or look for actual valid
+// references (complex but cleanest output).
+// Looking for the 2nd character gives us a middle ground.
+// The `#` is for (decimal and hexadecimal) numeric references, the letters
+// are for the named references.
+function encodeJsx(value) {
+  return value.replace(/&(?=[#a-z])/gi, '&amp;')
+}
+
 let ForInStatement,
   FunctionDeclaration,
   RestElement,
@@ -989,6 +1000,126 @@ export const GENERATOR = {
   RegExpLiteral(node, state) {
     const { regex } = node
     state.write(`/${regex.pattern}/${regex.flags}`, node)
+  },
+}
+
+export const JSX = {
+  // `attr`
+  // `attr="something"`
+  // `attr={1}`
+  JSXAttribute(node, state) {
+    this[node.name.type](node.name, state)
+
+    if (node.value !== undefined && node.value !== null) {
+      state.write('=')
+
+      // Encode double quotes in attribute values.
+      if (node.value.type === 'Literal') {
+        state.write(
+          '"' +
+            encodeJsx(String(node.value.value)).replace(/"/g, '&quot;') +
+            '"',
+          node,
+        )
+      } else {
+        this[node.value.type](node.value, state)
+      }
+    }
+  },
+  // `</div>`
+  JSXClosingElement(node, state) {
+    state.write('</')
+    this[node.name.type](node.name, state)
+    state.write('>')
+  },
+  // `</>`
+  JSXClosingFragment(node, state) {
+    state.write('</>', node)
+  },
+  // `<div />`
+  // `<div></div>`
+  JSXElement(node, state) {
+    let index = -1
+
+    this[node.openingElement.type](node.openingElement, state)
+
+    if (node.children) {
+      while (++index < node.children.length) {
+        this[node.children[index].type](node.children[index], state)
+      }
+    }
+
+    if (node.closingElement) {
+      this[node.closingElement.type](node.closingElement, state)
+    }
+  },
+  // `{}` (always in a `JSXExpressionContainer`, which does the curlies)
+  JSXEmptyExpression() {},
+  // `{expression}`
+  JSXExpressionContainer(node, state) {
+    state.write('{')
+    this[node.expression.type](node.expression, state)
+    state.write('}')
+  },
+  // `<></>`
+  JSXFragment(node, state) {
+    let index = -1
+
+    this[node.openingFragment.type](node.openingElement, state)
+
+    if (node.children) {
+      while (++index < node.children.length) {
+        this[node.children[index].type](node.children[index], state)
+      }
+    }
+
+    this[node.closingFragment.type](node.closingElement, state)
+  },
+  // `div`
+  JSXIdentifier(node, state) {
+    state.write(node.name, node)
+  },
+  // `member.expression`
+  JSXMemberExpression(node, state) {
+    this[node.object.type](node.object, state)
+    state.write('.')
+    this[node.property.type](node.property, state)
+  },
+  // `ns:name`
+  JSXNamespacedName(node, state) {
+    this[node.namespace.type](node.namespace, state)
+    state.write(':')
+    this[node.name.type](node.name, state)
+  },
+  // `<div>`
+  JSXOpeningElement(node, state) {
+    let index = -1
+
+    state.write('<')
+    this[node.name.type](node.name, state)
+
+    if (node.attributes) {
+      while (++index < node.attributes.length) {
+        state.write(' ')
+        this[node.attributes[index].type](node.attributes[index], state)
+      }
+    }
+
+    state.write(node.selfClosing ? ' />' : '>')
+  },
+  // `<>`
+  JSXOpeningFragment(node, state) {
+    state.write('<>', node)
+  },
+  // `{...argument}`
+  JSXSpreadAttribute(node, state) {
+    state.write('{')
+    this.SpreadElement(node, state)
+    state.write('}')
+  },
+  // `!`
+  JSXText(node, state) {
+    state.write(encodeJsx(node.value), node)
   },
 }
 

--- a/src/tests/astring.js
+++ b/src/tests/astring.js
@@ -8,6 +8,8 @@ import { pick } from 'lodash'
 import { generate } from '../astring'
 import { readFile } from './tools'
 
+import './jsx'
+
 const FIXTURES_FOLDER = path.join(__dirname, 'fixtures')
 
 const ecmaVersion = 12

--- a/src/tests/jsx.js
+++ b/src/tests/jsx.js
@@ -1,0 +1,439 @@
+import test from 'ava'
+import { generate, GENERATOR, JSX } from '../astring'
+
+const generator = { ...GENERATOR, ...JSX }
+
+test('JSX', (assert) => {
+  assert.is(
+    generate(
+      { type: 'JSXAttribute', name: { type: 'JSXIdentifier', name: 'a' } },
+      { generator },
+    ),
+    'a',
+    'should support an attribute',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: {
+          type: 'JSXNamespacedName',
+          namespace: { type: 'JSXIdentifier', name: 'a' },
+          name: { type: 'JSXIdentifier', name: 'b' },
+        },
+      },
+      { generator },
+    ),
+    'a:b',
+    'should support an attribute w/ a namespaced name',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: { type: 'Literal', value: 'b' },
+      },
+      { generator },
+    ),
+    'a="b"',
+    'should support an attribute w/ value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: { type: 'Literal', value: 'b' },
+      },
+      { generator },
+    ),
+    'a="b"',
+    'should support an attribute w/ a literal value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: { type: 'Literal', value: 'b"c' },
+      },
+      { generator },
+    ),
+    'a="b&quot;c"',
+    'should support an attribute w/ quotes in a value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: { type: 'Literal', value: 'b & c' },
+      },
+      { generator },
+    ),
+    'a="b & c"',
+    'should support an attribute w/ ampersands in a value (1)',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: { type: 'Literal', value: 'b &amp; c' },
+      },
+      { generator },
+    ),
+    'a="b &amp;amp; c"',
+    'should support an attribute w/ ampersands in a value (2)',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: {
+          type: 'JSXExpressionContainer',
+          expression: { type: 'Literal', value: 1 },
+        },
+      },
+      { generator },
+    ),
+    'a={1}',
+    'should support an attribute w/ an expression value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: {
+          type: 'JSXFragment',
+          openingFragment: { type: 'JSXOpeningFragment' },
+          closingFragment: { type: 'JSXClosingFragment' },
+          children: [{ type: 'JSXText', value: '1' }],
+        },
+      },
+      { generator },
+    ),
+    'a=<>1</>',
+    'should support an attribute w/ a fragment value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXAttribute',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        value: {
+          type: 'JSXElement',
+          openingElement: {
+            type: 'JSXOpeningElement',
+            name: { type: 'JSXIdentifier', name: 'b' },
+            selfClosing: true,
+          },
+        },
+      },
+      { generator },
+    ),
+    'a=<b />',
+    'should support an attribute w/ an element value',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXClosingElement',
+        name: { type: 'JSXIdentifier', name: 'a' },
+      },
+      { generator },
+    ),
+    '</a>',
+    'should support a closing element',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXClosingElement',
+        name: {
+          type: 'JSXMemberExpression',
+          object: { type: 'JSXIdentifier', name: 'a' },
+          property: { type: 'JSXIdentifier', name: 'b' },
+        },
+      },
+      { generator },
+    ),
+    '</a.b>',
+    'should support a closing element w/ a member name',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXClosingElement',
+        name: {
+          type: 'JSXNamespacedName',
+          namespace: { type: 'JSXIdentifier', name: 'a' },
+          name: { type: 'JSXIdentifier', name: 'b' },
+        },
+      },
+      { generator },
+    ),
+    '</a:b>',
+    'should support a closing element w/ a namespace name',
+  )
+
+  assert.is(
+    generate({ type: 'JSXClosingFragment' }, { generator }),
+    '</>',
+    'should support a closing fragment',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+          selfClosing: true,
+        },
+      },
+      { generator },
+    ),
+    '<a />',
+    'should support a JSX element w/ `selfClosing`',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+        },
+      },
+      { generator },
+    ),
+    '<a></a>',
+    'should support a JSX element w/ a closing element',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: { type: 'JSXIdentifier', name: 'a' },
+        },
+        children: [{ type: 'JSXText', value: 'b' }],
+      },
+      { generator },
+    ),
+    '<a>b</a>',
+    'should support a JSX element w/ children',
+  )
+
+  assert.is(
+    generate({ type: 'JSXEmptyExpression' }, { generator }),
+    '',
+    'should support a JSX empty expression',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXExpressionContainer',
+        expression: { type: 'Literal', value: 1 },
+      },
+      { generator },
+    ),
+    '{1}',
+    'should support a JSX expression container',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXFragment',
+        openingFragment: { type: 'JSXOpeningFragment' },
+        closingFragment: { type: 'JSXClosingFragment' },
+      },
+      { generator },
+    ),
+    '<></>',
+    'should support a JSX fragment',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXFragment',
+        openingFragment: { type: 'JSXOpeningFragment' },
+        closingFragment: { type: 'JSXClosingFragment' },
+        children: [{ type: 'JSXText', value: 'a' }],
+      },
+      { generator },
+    ),
+    '<>a</>',
+    'should support a JSX fragment w/ children',
+  )
+
+  assert.is(
+    generate({ type: 'JSXIdentifier', name: 'a' }, { generator }),
+    'a',
+    'should support a JSX identifier',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXMemberExpression',
+        object: { type: 'JSXIdentifier', name: 'a' },
+        property: { type: 'JSXIdentifier', name: 'b' },
+      },
+      { generator },
+    ),
+    'a.b',
+    'should support a JSX member expression',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXMemberExpression',
+        object: {
+          type: 'JSXMemberExpression',
+          object: { type: 'JSXIdentifier', name: 'a' },
+          property: { type: 'JSXIdentifier', name: 'b' },
+        },
+        property: { type: 'JSXIdentifier', name: 'c' },
+      },
+      { generator },
+    ),
+    'a.b.c',
+    'should support a JSX member expression w/ another member as `object`',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXNamespacedName',
+        namespace: { type: 'JSXIdentifier', name: 'a' },
+        name: { type: 'JSXIdentifier', name: 'b' },
+      },
+      { generator },
+    ),
+    'a:b',
+    'should support a JSX namespace name',
+  )
+
+  assert.is(
+    generate(
+      { type: 'JSXOpeningElement', name: { type: 'JSXIdentifier', name: 'a' } },
+      { generator },
+    ),
+    '<a>',
+    'should support a JSX opening element',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXOpeningElement',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        selfClosing: true,
+      },
+      { generator },
+    ),
+    '<a />',
+    'should support a JSX opening element w/ selfClosing',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXOpeningElement',
+        name: { type: 'JSXIdentifier', name: 'a' },
+        attributes: [
+          { type: 'JSXAttribute', name: { type: 'JSXIdentifier', name: 'b' } },
+          {
+            type: 'JSXAttribute',
+            name: { type: 'JSXIdentifier', name: 'c' },
+            value: { type: 'Literal', value: 'd' },
+          },
+          {
+            type: 'JSXAttribute',
+            name: { type: 'JSXIdentifier', name: 'e' },
+            value: {
+              type: 'JSXExpressionContainer',
+              expression: { type: 'Literal', value: 1 },
+            },
+          },
+          {
+            type: 'JSXSpreadAttribute',
+            argument: { type: 'Identifier', name: 'f' },
+          },
+        ],
+      },
+      { generator },
+    ),
+    '<a b c="d" e={1} {...f}>',
+    'should support a JSX opening element w/ attributes',
+  )
+
+  assert.is(
+    generate({ type: 'JSXOpeningFragment' }, { generator }),
+    '<>',
+    'should support an opening fragment',
+  )
+
+  assert.is(
+    generate(
+      {
+        type: 'JSXSpreadAttribute',
+        argument: { type: 'Identifier', name: 'a' },
+      },
+      { generator },
+    ),
+    '{...a}',
+    'should support a spread attribute',
+  )
+
+  assert.is(
+    generate({ type: 'JSXText', value: 'a' }, { generator }),
+    'a',
+    'should support a JSX text',
+  )
+
+  assert.is(
+    generate({ type: 'JSXText', value: 'a & b' }, { generator }),
+    'a & b',
+    'should support a JSX text w/ an ampersand (1)',
+  )
+
+  assert.is(
+    generate({ type: 'JSXText', value: 'a&b' }, { generator }),
+    'a&amp;b',
+    'should support a JSX text w/ an ampersand (2)',
+  )
+})


### PR DESCRIPTION
* Add new `JSX` export, similar to `GENERATOR`, with handlers for JSX nodes
* Add unit tests for JSX nodes
* Add JSX example

---

* I’m a fan of small unit tests over checking whole documents, so I tested the new features with those
* Types are not tested, and I’m not a TS user, so I didn’t add types for `JSX`. For reference, if you’re interested, [here is an example of how to test types](https://github.com/micromark/micromark-extension-gfm-strikethrough/pull/2/files). You could also opt to use JSDoc for typescript if the source is JS, which I quite like, [like so](https://github.com/wooorm/xdm/pull/2). Some complexity with types though is that newer ESTree proposal aren’t typed yet, such as bigint (and I’m not sure where JSX is typed)