### PR TITLE
chore: Add GENERATOR declaration

### DIFF
--- a/astring.d.ts
+++ b/astring.d.ts
@@ -75,3 +75,8 @@ interface Node {
  */
 export function generate(node: Node, options?: Options<null>): string
 export function generate(node: Node, options?: Options<Writable>): Writable
+
+/**
+ * The Base Generator
+ */
+export const GENERATOR: Generator;

--- a/astring.d.ts
+++ b/astring.d.ts
@@ -77,6 +77,6 @@ export function generate(node: Node, options?: Options<null>): string
 export function generate(node: Node, options?: Options<Writable>): Writable
 
 /**
- * The Base Generator
+ * Base code generator.
  */
 export const GENERATOR: Generator;


### PR DESCRIPTION
baseGenerator/GENERATOR is missing in the type definition file