### PR TITLE
TODO: move after condition when babili fix 430

### DIFF
--- a/src/astring.js
+++ b/src/astring.js
@@ -532,10 +532,8 @@ export const GENERATOR = {
     state.write('import ')
     const { specifiers } = node
     const { length } = specifiers
-    // TODO: Once babili is fixed, put this after condition
-    // https://github.com/babel/babili/issues/430
-    let i = 0
     if (length > 0) {
+      let i = 0
       for (; i < length; ) {
         if (i > 0) {
           state.write(', ')


### PR DESCRIPTION
Hi, I used your code in a personal project and saw the _"TODO: Once babili is fixed, put this after condition"_ comment in your code. I've reviewed the issue you were referencing `[](https://github.com/babel/babili/issues/430) and it is fixed, so I went ahead a moved the variable declaration after the condition. 

I run the npm run test after the change and all 7 tests still passing.
<img width="724" alt="Screen Shot 2022-03-07 at 7 36 08 PM" src="https://user-images.githubusercontent.com/34435120/157161385-d6e31103-3db9-4a52-969b-d92b1cbaf847.png">

