### PR TITLE
Fix types for the new node16 module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     "import": "./dist/astring.mjs",
     "require": "./dist/astring.js",
-    "browser": "./dist/astring.min.js"
+    "browser": "./dist/astring.min.js",
+    "types": "./astring.d.ts"
   },
   "bin": {
     "astring": "bin/astring"


### PR DESCRIPTION
When the TypeScript `module` option is set to `node16` and a dependency uses `exports`, TypeScript looks at `exports.types` instead of `types`