### PR TITLE
feat: add stringify option

### DIFF
--- a/astring.d.ts
+++ b/astring.d.ts
@@ -60,6 +60,10 @@ export interface Options<Output = null> {
    * Custom code generator logic.
    */
   generator?: Generator
+	/**
+	 * Custom stringifier for translating literals to code.
+	 */
+	stringify?: (value: string|number|boolean, parentNode: EstreeNode) => string
 }
 
 /**

--- a/src/astring.js
+++ b/src/astring.js
@@ -8,8 +8,6 @@
 // Please use the GitHub bug tracker to report issues:
 // https://github.com/davidbonnet/astring/issues
 
-const { stringify } = JSON
-
 /* c8 ignore if */
 if (!String.prototype.repeat) {
   /* c8 ignore next */
@@ -814,11 +812,11 @@ export const GENERATOR = {
           this[node.key.type](node.key, state)
           state.write(']')
         } else {
-          this[node.key.type](node.key, state)
+          this[node.key.type](node.key, state, node)
         }
         state.write(': ')
       }
-      this[node.value.type](node.value, state)
+      this[node.value.type](node.value, state, node)
     }
   },
   PropertyDefinition(node, state) {
@@ -1010,7 +1008,7 @@ export const GENERATOR = {
   PrivateIdentifier(node, state) {
     state.write(`#${node.name}`, node)
   },
-  Literal(node, state) {
+  Literal(node, state, parent) {
     if (node.raw != null) {
       // Non-standard property
       state.write(node.raw, node)
@@ -1019,7 +1017,7 @@ export const GENERATOR = {
     } else if (node.bigint != null) {
       state.write(node.bigint + 'n', node)
     } else {
-      state.write(stringify(node.value), node)
+      state.write(state.stringify(node.value, parent), node)
     }
   },
   RegExpLiteral(node, state) {
@@ -1057,6 +1055,7 @@ class State {
     this.indentLevel =
       setup.startingIndentLevel != null ? setup.startingIndentLevel : 0
     this.writeComments = setup.comments ? setup.comments : false
+		this.stringify = setup.stringify ? setup.stringify : (value) => JSON.stringify(value)
     // Source map
     if (setup.sourceMap != null) {
       this.write =


### PR DESCRIPTION
This PR adds a new `stringify` option to the list of available options. This option can replace the default `JSON.stringify` used to convert a literal to a valid JavaScript value.

## Context

I need this for a project where I take an object, convert it to an ESTree AST through [estree-util-value-to-estree](https://github.com/remcohaszing/estree-util-value-to-estree), and convert it back to code through `astring`.

The goal of the project is to allow modifying a generic configuration file (in our case, `vite.config.ts` to add options to it. For instance:

```ts
addPlugin('@vitejs/plugn-vue', { reactivityTransform: true })
```

With the above API, the second parameter is the object I want to convert to an AST and convert back to code. 

This currently works, but I have no say about the formatting of the literals - and I want to preserve the codestyle from the existing file (that I already have inferred). 

## Solution

The solution is for `astring` to offer a way to customize how literals are translated to code. This way, I can wrap (or not) with single quotes or double quotes depending on the project.

## Implementation

I added a new configuration option named `stringify`. If it is not given, the default one is used and the current behavior stays the same.

Otherwise, it is used to translate nodes of type `Literal`. It takes two parameters: the value (can be a string, bool or number) and the parent node. The parent node is useful to determine whether the current value is the key or the value of an ObjectLiteral.