### PR TITLE
feat: import/export of literal string names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@babel/generator": "^7.14.3",
         "@babel/parser": "^7.16.4",
         "@babel/preset-env": "^7.14.4",
-        "acorn": "^8.6.0",
+        "acorn": "^8.12.1",
         "acorn-import-attributes": "^1.9.5",
         "astravel": "^0.5.0",
         "ava": "^3.15.0",
@@ -2804,9 +2804,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/generator": "^7.14.3",
     "@babel/parser": "^7.16.4",
     "@babel/preset-env": "^7.14.4",
-    "acorn": "^8.6.0",
+    "acorn": "^8.12.1",
     "acorn-import-attributes": "^1.9.5",
     "astravel": "^0.5.0",
     "ava": "^3.15.0",

--- a/src/astring.js
+++ b/src/astring.js
@@ -567,10 +567,11 @@ export const GENERATOR = {
         state.write('{')
         for (;;) {
           const specifier = specifiers[i]
-          const { name } = specifier.imported
-          state.write(name, specifier)
-          if (name !== specifier.local.name) {
-            state.write(' as ' + specifier.local.name)
+          const { imported, local } = specifier
+          this[imported.type](imported, state)
+          if (local.type === 'Literal' || imported.name !== local.name) {
+            state.write(' as ')
+            this[local.type](local, state)
           }
           if (++i < length) {
             state.write(', ')
@@ -626,11 +627,16 @@ export const GENERATOR = {
         { length } = specifiers
       if (length > 0) {
         for (let i = 0; ; ) {
-          const specifier = specifiers[i]
-          const { name } = specifier.local
-          state.write(name, specifier)
-          if (name !== specifier.exported.name) {
-            state.write(' as ' + specifier.exported.name)
+          const { local, exported } = specifiers[i]
+          this[local.type](local, state)
+          if (
+            local.type !== exported.type
+            || (local.type === 'Literal'
+              ? local.value !== exported.value
+              : local.name !== exported.name)
+          ) {
+            state.write(' as ')
+            this[exported.type](exported, state)
           }
           if (++i < length) {
             state.write(', ')

--- a/src/astring.js
+++ b/src/astring.js
@@ -666,7 +666,9 @@ export const GENERATOR = {
   },
   ExportAllDeclaration(node, state) {
     if (node.exported != null) {
-      state.write('export * as ' + node.exported.name + ' from ')
+      state.write('export * as ')
+      this[node.exported.type](node.exported, state)
+      state.write(' from ')
     } else {
       state.write('export * from ')
     }

--- a/src/tests/fixtures/syntax/export.js
+++ b/src/tests/fixtures/syntax/export.js
@@ -1,5 +1,5 @@
 export * from "module";
-export * as m from "module";
+export * as module from "module";
 export {name} from "module";
 export {a as b, c as d} from "module";
 let e, g;
@@ -10,3 +10,6 @@ export var j = 42;
 export let k = 42;
 export function l() {}
 export {val} from '../other/a.json' with { type: "json" };
+let m, n, o, p;
+export {m as "m"};
+export {n as "n", "o" as o, "p"} from "module";

--- a/src/tests/fixtures/syntax/import.js
+++ b/src/tests/fixtures/syntax/import.js
@@ -8,3 +8,4 @@ import * as q from "../other/a.json" with { type: "json" };
 import r from "../other/a.json" with { type: "json" };
 import("module");
 const x = import("module");
+import {"s" as t} from "module";


### PR DESCRIPTION
Closes #713

Foreign names can be string literals, like so:

```js
export {m as "m"};
export {n as "n", "o" as o, "p"} from "module";
import {"s" as t} from "module";
```

This implementation is incomplete. Changing `ExportAllDeclaration` to support this raised an issue with testing (specifically with acorn-import-attributes), and fixing it would make the PR too large.